### PR TITLE
Fix a typo in variable name

### DIFF
--- a/hanging_threads.py
+++ b/hanging_threads.py
@@ -93,7 +93,7 @@ def monitor():
                frame_list != old_threads[thread_id][0]:
                 new_threads[thread_id] = (frame_list, now)
             elif old_threads[thread_id][1] < then:
-                print_frame_list(frame_list, frame_id)
+                print_frame_list(frame_list, thread_id)
             else:
                 new_threads[thread_id] = old_threads[thread_id]
         old_threads = new_threads


### PR DESCRIPTION
This seems like a typo because you use another variable name in the second loop.