### PR TITLE
Add deployment process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ script:
 # test that the tag represents the version
 # https://docs.travis-ci.com/user/environment-variables/#Default-Environment-Variables
 - ( if [ -n "$TRAVIS_TAG" ]; then if [ $TAG_NAME != $TRAVIS_TAG ]; then echo "This tag is for the wrong version. Got \"$TRAVIS_TAG\" expected \"$TAG_NAME\"."; exit 1; fi; fi; )
-- ./create-tag-on-deploy-branch.sh "$TAG_DEPLOY_URL"
 before_deploy:
 - pip install wheel
 - python setup.py bdist_wheel
@@ -30,7 +29,7 @@ deploy:
 # created with travis command line tool
 # https://docs.travis-ci.com/user/deployment/pypi
 # $ travis setup pypi
-  provider: pypi
+- provider: pypi
   user: niccokunzmann2
   password:
       secure: "dwc7byX2ekHQKzMOT8j3deLMERffIIIkMYcU6zjeW/Y9EhG+iECpm4zwKHR5ypRn9GazgUoMs3fEMS88GhW1ukKtqNzcA9Gb8fjDiAgjmW+Roo3uuoQRxFnVFVVxup0+xmOpmyIvYeDZq0/QiI0vD1Wx6mKCnfrwrWc9k4AcXSpDCCkBhIrqwbKTWx9dWsqZuELy+J1pM8+nTqFHzmwfuqVC1MuI6JCs/6vgVmRdjyYChSZvMPKuLkQp/rhIzYDYk4ZHDKrAHTQSQfkqAFadeb/BPldVk2Fr21p+KHKgPrhOayc4YQ+Dd6kRaB+yWQAbJJCCRgvpyqAofN3jJomekoEJXuvJvL22Ry9esBuD5GA9Qydt7+qaiRfZgUmxxPxOGYPvV813ghrk2m7dom+fMQmBN22+ajdHzQlpA8jQ1yeUiJXgGn/hkR2Wpbp6xRj3bjjK7IuZCqNGrskN4QTaypYKjXLujgFTZeXL15RpxAA9b638xYG1nIhcugKVsH61ahfg+6Vjv6sUOdqK495D20xMIBW0J0Zo5JTyd3/oQVs8fuCX+96g+eMNeoIplUBzcUyBoXb/q3EArh9WVCAVGV398zS19l/w8lh+eobS02eg5Za6WA6K+PpeIi3meGb0ClEq8zb21Or16s2+La/STeM6zEKMVPtWEo4NI7IHIO4="
@@ -38,3 +37,8 @@ deploy:
     tags: true
     distributions: sdist bdist_wheel
     repo: niccokunzmann/hanging_threads
+- provider: script
+  script: ./create-tag-on-deploy-branch.sh "$TAG_DEPLOY_URL"
+  on:
+    # only create a new tag on one python version
+    condition: "$TRAVIS_PYTHON_VERSION" == "3.5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ script:
 # test that the tag represents the version
 # https://docs.travis-ci.com/user/environment-variables/#Default-Environment-Variables
 - ( if [ -n "$TRAVIS_TAG" ]; then if [ $TAG_NAME != $TRAVIS_TAG ]; then echo "This tag is for the wrong version. Got \"$TRAVIS_TAG\" expected \"$TAG_NAME\"."; exit 1; fi; fi; )
+- ./create-tag-on-deploy-branch.sh
 before_deploy:
 - pip install wheel
 - python setup.py bdist_wheel

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ script:
 # test that the tag represents the version
 # https://docs.travis-ci.com/user/environment-variables/#Default-Environment-Variables
 - ( if [ -n "$TRAVIS_TAG" ]; then if [ $TAG_NAME != $TRAVIS_TAG ]; then echo "This tag is for the wrong version. Got \"$TRAVIS_TAG\" expected \"$TAG_NAME\"."; exit 1; fi; fi; )
-- ./create-tag-on-deploy-branch.sh
+- ./create-tag-on-deploy-branch.sh "$TAG_DEPLOY_URL"
 before_deploy:
 - pip install wheel
 - python setup.py bdist_wheel

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,3 +41,4 @@ deploy:
   on:
     # only create a new tag on one python version
     condition: $TRAVIS_PYTHON_VERSION == 3.5
+    all_branches: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,10 +35,9 @@ deploy:
       secure: "dwc7byX2ekHQKzMOT8j3deLMERffIIIkMYcU6zjeW/Y9EhG+iECpm4zwKHR5ypRn9GazgUoMs3fEMS88GhW1ukKtqNzcA9Gb8fjDiAgjmW+Roo3uuoQRxFnVFVVxup0+xmOpmyIvYeDZq0/QiI0vD1Wx6mKCnfrwrWc9k4AcXSpDCCkBhIrqwbKTWx9dWsqZuELy+J1pM8+nTqFHzmwfuqVC1MuI6JCs/6vgVmRdjyYChSZvMPKuLkQp/rhIzYDYk4ZHDKrAHTQSQfkqAFadeb/BPldVk2Fr21p+KHKgPrhOayc4YQ+Dd6kRaB+yWQAbJJCCRgvpyqAofN3jJomekoEJXuvJvL22Ry9esBuD5GA9Qydt7+qaiRfZgUmxxPxOGYPvV813ghrk2m7dom+fMQmBN22+ajdHzQlpA8jQ1yeUiJXgGn/hkR2Wpbp6xRj3bjjK7IuZCqNGrskN4QTaypYKjXLujgFTZeXL15RpxAA9b638xYG1nIhcugKVsH61ahfg+6Vjv6sUOdqK495D20xMIBW0J0Zo5JTyd3/oQVs8fuCX+96g+eMNeoIplUBzcUyBoXb/q3EArh9WVCAVGV398zS19l/w8lh+eobS02eg5Za6WA6K+PpeIi3meGb0ClEq8zb21Or16s2+La/STeM6zEKMVPtWEo4NI7IHIO4="
   on:
     tags: true
-    distributions: sdist bdist_wheel
     repo: niccokunzmann/hanging_threads
 - provider: script
   script: ./create-tag-on-deploy-branch.sh "$TAG_DEPLOY_URL"
   on:
     # only create a new tag on one python version
-    condition: "$TRAVIS_PYTHON_VERSION" == "3.5"
+    condition: $TRAVIS_PYTHON_VERSION == 3.5

--- a/create-tag-on-deploy-branch.sh
+++ b/create-tag-on-deploy-branch.sh
@@ -11,9 +11,22 @@ echo "(1) check if we are on a deploy branch of the form vNUMBER.NUMBER"
 
 # get current branch name
 # http://stackoverflow.com/a/1418022/367456
-current_branch="`git rev-parse --abbrev-ref HEAD`"
+if [ "$TRAVIS_PULL_REQUEST" == "false" ] || [ -z "$TRAVIS_PULL_REQUEST" ]
+then
+  echo "This is not a pull request."
+  if [ -z "$TRAVIS_BRANCH" ]
+  then
+    echo "This seems to be executed locally and not on travis. Getting current branch."
+    current_branch="`git rev-parse --abbrev-ref HEAD`"
+  else
+    echo "We are on travis and can use the environment variables to know the branch."
+    current_branch="$TRAVIS_BRANCH"
+  fi
+else
+  echo "This is a pull request. We can not build from a pull request."
+  exit 0
+fi
 
-# TODO: test for pull-requests from deploy branches
 if echo "$current_branch" | grep -qE '^v[[:digit:]]+\.[[:digit:]]+$'
 then
   echo "Branch $current_branch is a deploy branch."

--- a/create-tag-on-deploy-branch.sh
+++ b/create-tag-on-deploy-branch.sh
@@ -69,7 +69,9 @@ cat "$file" | grep -F "__version__"
 
 echo "(5) Create git tag `new_tag`"
 git add "$file"
-git commit -m"automatic commit by `whoami`@`hostname` for tag `new_tag` $TRAVIS_BUILD_NUMBER" --author="`whoami` <`whoami`@`hostname`>" || true
+git config user.email || git config user.email "travis@travis-ci.org"
+git config user.name || git config user.name "Travis CI"
+git commit -m"automatic commit by `whoami`@`hostname` for tag `new_tag` $TRAVIS_BUILD_NUMBER"
 git tag "`new_tag`"
 
 echo "(6) pushing back to travis"

--- a/create-tag-on-deploy-branch.sh
+++ b/create-tag-on-deploy-branch.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+#
+# When we are on a branch of the form vNUNMBER.NUMBER,
+# for each commit, we replace the __version__ information
+# in the hanging_threads.py with a running number of tags,
+# i.E. branch v2.1 leads to the tags v2.1.0, v2.1.1, ... .
+#
+set -e
+
+echo "(1) check if we are on a deploy branch of the form vNUMBER.NUMBER"
+
+# get current branch name
+# http://stackoverflow.com/a/1418022/367456
+current_branch="`git rev-parse --abbrev-ref HEAD`"
+
+# TODO: test for pull-requests from deploy branches
+if echo "$current_branch" | grep -qE '^v[[:digit:]]+\.[[:digit:]]+$'
+then
+  echo "Branch $current_branch is a deploy branch."
+else
+  echo "Branch $current_branch is not a deploy branch."
+  exit 0
+fi
+
+echo "(2) Check if we are not on a tag to prevent build loops."
+# http://stackoverflow.com/a/27911598/1320237
+git fetch --tags
+tags_to_head="`git tag --points-at HEAD`"
+if [ -n "$tags_to_head" ]
+then
+  echo "The tag" $tags_to_head "points to this commit. It cannot be used to create a new tag."
+  exit 0
+else
+  echo "This commit has no tags pointing at it. It can be used for a build."
+fi
+
+echo "(3) compute increasing tag number"
+
+tags="`git tag -l \"${current_branch}.*\"`"
+echo "Previous tags:" $tags
+i=0
+function new_tag() {
+  echo -n "$current_branch.$i"
+}
+while echo "$tags" | grep -qx "`new_tag`"
+do
+  # arithmetic http://stackoverflow.com/a/6348941/1320237
+  i=$((i + 1))
+done
+echo "The new tag is `new_tag`"
+
+echo "(4) change version of hanging_threads.py"
+file="hanging_threads.py"
+sed -ri "0,/__version__\\s*=\\s*(\"[^\"]*\"|'[^']*')/ s//__version__ = \"`new_tag`\"/" "$file"
+cat "$file" | grep -F "__version__"
+
+echo "(5) Create git tag `new_tag`"
+git add "$file"
+git commit -m"automatic commit by `whoami`@`hostname` for tag `new_tag` $TRAVIS_BUILD_NUMBER" --author="`whoami` <`whoami`@`hostname`>" || true
+git tag "`new_tag`"
+
+echo "(6) pushing back to travis"
+push_url="$1"
+if [ -z "$push_url" ]
+then
+  echo "No push url found as first argument. Will not push the tag `new_tag`."
+  exit 0
+else
+  echo "Push url found as first argument! Trying to push."
+fi
+
+# Using ideas from https://gist.github.com/willprice/e07efd73fb7f13f917ea
+# piping away the output because it could contain the url
+if git push --quiet "$push_url" "`new_tag`" 1>>/dev/null 2>>/dev/null
+then
+  echo "Push successful."
+else
+  echo "Push failed."
+  exit 1
+fi

--- a/developing.md
+++ b/developing.md
@@ -1,15 +1,36 @@
 Notes on Development
 ====================
 
-Test:
+Deployment
+----------
+
+We have branches for versions such as `v2.1`.
+They have the form `vNUMBER.NUMBER`
+They are the base branches for deployment.
+
+Whenever a commit is created in these branches,
+[travis][travis] does the following:
+
+1. Test the branch
+2. Create a new tag with increasing number.
+   I.e. for the branch `v2.1` the tag `v2.1.0` is created,
+   if this exists `v2.1.1` and so on.
+   This tag is pushed to github.
+
+Whenever a tag is built with [travis][travis], the following is checked:
+
+1. Does the tag correspond to the `__version__` variable on the module?
+2. If yes, the current build is pushed to [pypi][pypi].
+
+Test
 ----
 
 ```sh
 python hanging_threads.py
 ```
 
-Upload
-------
+Manual Upload
+-------------
 
 To install wheel:
 
@@ -28,3 +49,6 @@ Upload Windows:
 ```
 py -3.4 setup.py bdist_wheel sdist upload
 ```
+
+[travis]: https://github.com/niccokunzmann/hanging_threads
+[pypi]: https://pypi.python.org/pypi/hanging_threads

--- a/hanging_threads.py
+++ b/hanging_threads.py
@@ -29,7 +29,7 @@ except ImportError:
 import linecache
 import time
 
-__version__ = "v0.0.7"
+__version__ = "to be replaced by travis ci"
 __author__ = "Nicco Kunzmann"
 
 

--- a/hanging_threads.py
+++ b/hanging_threads.py
@@ -29,7 +29,7 @@ except ImportError:
 import linecache
 import time
 
-__version__ = "2.0.0"
+__version__ = "v0.0.4"
 __author__ = "Nicco Kunzmann"
 
 

--- a/hanging_threads.py
+++ b/hanging_threads.py
@@ -29,7 +29,7 @@ except ImportError:
 import linecache
 import time
 
-__version__ = "v0.0.4"
+__version__ = "v0.0.5"
 __author__ = "Nicco Kunzmann"
 
 

--- a/hanging_threads.py
+++ b/hanging_threads.py
@@ -29,7 +29,7 @@ except ImportError:
 import linecache
 import time
 
-__version__ = "v0.0.6"
+__version__ = "v0.0.7"
 __author__ = "Nicco Kunzmann"
 
 

--- a/hanging_threads.py
+++ b/hanging_threads.py
@@ -29,7 +29,7 @@ except ImportError:
 import linecache
 import time
 
-__version__ = "to be replaced by travis ci"
+__version__ = "development"
 __author__ = "Nicco Kunzmann"
 
 

--- a/hanging_threads.py
+++ b/hanging_threads.py
@@ -29,7 +29,7 @@ except ImportError:
 import linecache
 import time
 
-__version__ = "v0.0.5"
+__version__ = "v0.0.6"
 __author__ = "Nicco Kunzmann"
 
 


### PR DESCRIPTION
fixes issue #26 

- there is a script which can be executed on travis and locally to push a build tag
- I documented the deployment process in the developing.md file
- tag v0.0.7 was created this way.

When this is merged, we can rename the 2.x branch to a 2.0 branch and every commit to this branch will create a tag and a deployed version on pypi.

@artemrizhov What do you think?